### PR TITLE
Update kedro-dagster docs link following its migration

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,5 +4,5 @@ contact_links:
     about: Come chat with the Kedro community!
     url: https://slack.kedro.org
   - name: Documentation
-    url: https://gtauzin.github.io/kedro-dagster/
+    url: https://kedro-dagster.readthedocs.io/en/latest/
     about: To learn more about how Kedro-Dagster works

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 ![Powered by Kedro](https://img.shields.io/badge/powered_by-kedro-ffc900?logo=kedro)
 
-This repository aims to demonstrate the [`kedro-dagster`](https://github.com/gtauzin/kedro-dagster) plugin in the context of a real‑world, deployed Kedro project. For a full user guide centered around this example repository, see the [Kedro-Dagster documentation](https://gtauzin.github.io/kedro-dagster/pages/example/).
+This repository aims to demonstrate the [`kedro-dagster`](https://github.com/gtauzin/kedro-dagster) plugin in the context of a real‑world, deployed Kedro project. For a full user guide centered around this example repository, see the [Kedro-Dagster documentation](https://kedro-dagster.readthedocs.io/en/latest/pages/example/).
 
 <p align="center">
   <picture>


### PR DESCRIPTION
## Description
kedro-dagtser has moved to Read The Docs: gtauzin/kedro-dagster#30.

## Development notes
- Update links

## Checklist

- [ ] Opened this PR as a 'Draft Pull Request' if it is work-in-progress
- [ ] Updated the documentation to reflect the code changes
- [ ] Added a description of this change in the relevant `RELEASE.md` file
- [ ] Added tests to cover my changes
